### PR TITLE
Debugger layout fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gillianplatform/sedap",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gillianplatform/sedap",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "workspaces": [
         "./types",
         "./react",
@@ -9866,7 +9866,7 @@
     },
     "react": {
       "name": "@gillianplatform/sedap-react",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "ISC",
       "dependencies": {
         "@xyflow/react": "^12.3.6",
@@ -9878,7 +9878,7 @@
         "@eslint/compat": "^1.2.4",
         "@eslint/eslintrc": "^3.2.0",
         "@eslint/js": "^9.17.0",
-        "@gillianplatform/sedap-types": "0.0.1",
+        "@gillianplatform/sedap-types": "0.0.2",
         "@storybook/addon-essentials": "^8.4.7",
         "@storybook/addon-interactions": "^8.4.7",
         "@storybook/addon-onboarding": "^8.4.7",
@@ -9912,7 +9912,7 @@
     },
     "types": {
       "name": "@gillianplatform/sedap-types",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "ISC",
       "devDependencies": {
         "json-schema-to-typescript": "^15.0.3",
@@ -9922,14 +9922,14 @@
     },
     "vscode/ext": {
       "name": "@gillianplatform/sedap-vscode-ext",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "ISC",
       "devDependencies": {
         "@eslint/compat": "^1.2.4",
         "@eslint/eslintrc": "^3.2.0",
         "@eslint/js": "^9.17.0",
-        "@gillianplatform/sedap-types": "0.0.1",
-        "@gillianplatform/sedap-vscode-types": "0.0.1",
+        "@gillianplatform/sedap-types": "0.0.2",
+        "@gillianplatform/sedap-vscode-types": "0.0.2",
         "@types/vscode": "^1.96.0",
         "@typescript-eslint/eslint-plugin": "^8.18.2",
         "@typescript-eslint/parser": "^8.18.2",
@@ -9948,16 +9948,16 @@
     },
     "vscode/types": {
       "name": "@gillianplatform/sedap-vscode-types",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "ISC",
       "devDependencies": {
-        "@gillianplatform/sedap-types": "0.0.1",
+        "@gillianplatform/sedap-types": "0.0.2",
         "typescript": "^5.7.2"
       }
     },
     "vscode/ui": {
       "name": "@gillianplatform/sedap-vscode-ui",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "ISC",
       "dependencies": {
         "@xyflow/react": "^12.3.6",
@@ -9969,8 +9969,8 @@
         "@eslint/compat": "^1.2.4",
         "@eslint/eslintrc": "^3.2.0",
         "@eslint/js": "^9.17.0",
-        "@gillianplatform/sedap-types": "0.0.1",
-        "@gillianplatform/sedap-vscode-types": "0.0.1",
+        "@gillianplatform/sedap-types": "0.0.2",
+        "@gillianplatform/sedap-vscode-types": "0.0.2",
         "@types/react": "^19.0.2",
         "@types/vscode-webview": "^1.57.5",
         "@typescript-eslint/eslint-plugin": "^8.18.2",
@@ -9990,7 +9990,7 @@
         "vite-plugin-dts": "^4.4.0"
       },
       "peerDependencies": {
-        "@gillianplatform/sedap-react": "0.0.1",
+        "@gillianplatform/sedap-react": "0.0.2",
         "react": "^19.0.0",
         "react-icons": "^5.4.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2576,76 +2576,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@testing-library/jest-dom": {
-      "version": "6.6.3",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.6.3.tgz",
-      "integrity": "sha512-IteBhl4XqYNkM54f4ejhLRJiZNqcSCoXUOG2CPK7qbD322KjQozM4kHQOfkG2oln9b9HTYqs+Sae8vBATubxxA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@adobe/css-tools": "^4.4.0",
-        "aria-query": "^5.0.0",
-        "chalk": "^3.0.0",
-        "css.escape": "^1.5.1",
-        "dom-accessibility-api": "^0.6.3",
-        "lodash": "^4.17.21",
-        "redent": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6",
-        "yarn": ">=1"
-      }
-    },
-    "node_modules/@testing-library/jest-dom/node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
-      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@testing-library/react": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.2.0.tgz",
-      "integrity": "sha512-2cSskAvA1QNtKc8Y9VJQRv0tm3hLVgxRGDB+KYhIaPQJ1I+RHbhIXcM+zClKXzMes/wshsMVzf4B9vS4IZpqDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@testing-library/dom": "^10.0.0",
-        "@types/react": "^18.0.0 || ^19.0.0",
-        "@types/react-dom": "^18.0.0 || ^19.0.0",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@testing-library/user-event": {
       "version": "14.5.2",
       "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.2.tgz",
@@ -4110,155 +4040,6 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/concurrently": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.1.2.tgz",
-      "integrity": "sha512-H9MWcoPsYddwbOGM6difjVwVZHl63nwMEwDJG/L7VGtuaJhb12h2caPG2tVPWs7emuYix252iGfqOyrz1GczTQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "lodash": "^4.17.21",
-        "rxjs": "^7.8.1",
-        "shell-quote": "^1.8.1",
-        "supports-color": "^8.1.1",
-        "tree-kill": "^1.2.2",
-        "yargs": "^17.7.2"
-      },
-      "bin": {
-        "conc": "dist/bin/concurrently.js",
-        "concurrently": "dist/bin/concurrently.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
-      }
-    },
-    "node_modules/concurrently/node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/concurrently/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/concurrently/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/concurrently/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/concurrently/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/concurrently/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/concurrently/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/concurrently/node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/concurrently/node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/confbox": {
       "version": "0.2.1",
@@ -8374,16 +8155,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/rxjs": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
@@ -8555,19 +8326,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/shell-quote": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.2.tgz",
-      "integrity": "sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/side-channel": {
@@ -9204,16 +8962,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/tree-kill": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
-      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "tree-kill": "cli.js"
       }
     },
     "node_modules/ts-api-utils": {
@@ -10137,13 +9885,9 @@
         "@storybook/blocks": "^8.4.7",
         "@storybook/react": "^8.4.7",
         "@storybook/react-vite": "^8.4.7",
-        "@storybook/test": "^8.4.7",
-        "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.1.0",
         "@types/react": "^19.0.2",
         "@typescript-eslint/eslint-plugin": "^8.18.2",
         "@typescript-eslint/parser": "^8.18.2",
-        "concurrently": "^9.1.2",
         "eslint": "^9.17.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.2.1",
@@ -10189,7 +9933,6 @@
         "@types/vscode": "^1.96.0",
         "@typescript-eslint/eslint-plugin": "^8.18.2",
         "@typescript-eslint/parser": "^8.18.2",
-        "concurrently": "^9.1.2",
         "eslint": "^9.17.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.2.1",
@@ -10232,7 +9975,6 @@
         "@types/vscode-webview": "^1.57.5",
         "@typescript-eslint/eslint-plugin": "^8.18.2",
         "@typescript-eslint/parser": "^8.18.2",
-        "concurrently": "^9.1.2",
         "eslint": "^9.17.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gillianplatform/sedap",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Monorepo for JavaScript libraries for SEDAP",
   "repository":"https://github.com/gillianplatform/sedap-js",
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "./vscode/ui"
   ],
   "scripts": {
-    "check-versions": "node ./scripts/checkVersion.cjs"
+    "check-versions": "node ./scripts/checkVersion.cjs",
+    "build": "npm run build --workspaces --if-present"
   }
 }

--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gillianplatform/sedap-react",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "React components for SEDAP",
   "repository":"https://github.com/gillianplatform/sedap-js",
   "type": "module",
@@ -27,7 +27,7 @@
     "@eslint/compat": "^1.2.4",
     "@eslint/eslintrc": "^3.2.0",
     "@eslint/js": "^9.17.0",
-    "@gillianplatform/sedap-types": "0.0.1",
+    "@gillianplatform/sedap-types": "0.0.2",
     "@storybook/addon-essentials": "^8.4.7",
     "@storybook/addon-interactions": "^8.4.7",
     "@storybook/addon-onboarding": "^8.4.7",

--- a/react/src/components/nodes/EmptyNode.tsx
+++ b/react/src/components/nodes/EmptyNode.tsx
@@ -34,7 +34,7 @@ const TraceViewEmptyNode = ({ data }: NodeComponentProps) => {
   const { componentOverrides } = useContext(TraceViewContext);
   const Button = componentOverrides.stepButton || componentOverrides.button || RoundButton;
   return (
-    <NodeBase nodeKind="empty" targetHandle>
+    <NodeBase nodeKind="empty" targetHandle={!!prev}>
       <NodeBox>
         <Button onClick={onStepButtonClick} className="sedap__stepButton">
           <VscPlay />

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gillianplatform/sedap-types",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "SEDAP types for TypeScript",
   "repository":"https://github.com/gillianplatform/sedap-js",
   "types": "./src/index.d.ts",

--- a/vscode/ext/package.json
+++ b/vscode/ext/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gillianplatform/sedap-vscode-ext",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "SEDAP-related utilities for VSCode extensions",
   "repository":"https://github.com/gillianplatform/sedap-js",
   "type": "commonjs",
@@ -27,8 +27,8 @@
     "@eslint/compat": "^1.2.4",
     "@eslint/eslintrc": "^3.2.0",
     "@eslint/js": "^9.17.0",
-    "@gillianplatform/sedap-types": "0.0.1",
-    "@gillianplatform/sedap-vscode-types": "0.0.1",
+    "@gillianplatform/sedap-types": "0.0.2",
+    "@gillianplatform/sedap-vscode-types": "0.0.2",
     "@types/vscode": "^1.96.0",
     "@typescript-eslint/eslint-plugin": "^8.18.2",
     "@typescript-eslint/parser": "^8.18.2",

--- a/vscode/types/package.json
+++ b/vscode/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gillianplatform/sedap-vscode-types",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Types for SEDAP VSCode helper libraries",
   "repository":"https://github.com/gillianplatform/sedap-js",
   "types": "./src/index.d.ts",
@@ -8,7 +8,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@gillianplatform/sedap-types": "0.0.1",
+    "@gillianplatform/sedap-types": "0.0.2",
     "typescript": "^5.7.2"
   }
 }

--- a/vscode/ui/package.json
+++ b/vscode/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gillianplatform/sedap-vscode-ui",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "SEDAP-related utilities for webviews inside VSCode extensions",
   "repository":"https://github.com/gillianplatform/sedap-js",
   "type": "module",
@@ -25,8 +25,8 @@
     "@eslint/compat": "^1.2.4",
     "@eslint/eslintrc": "^3.2.0",
     "@eslint/js": "^9.17.0",
-    "@gillianplatform/sedap-types": "0.0.1",
-    "@gillianplatform/sedap-vscode-types": "0.0.1",
+    "@gillianplatform/sedap-types": "0.0.2",
+    "@gillianplatform/sedap-vscode-types": "0.0.2",
     "@types/react": "^19.0.2",
     "@types/vscode-webview": "^1.57.5",
     "@typescript-eslint/eslint-plugin": "^8.18.2",
@@ -46,7 +46,7 @@
     "vite-plugin-dts": "^4.4.0"
   },
   "peerDependencies": {
-    "@gillianplatform/sedap-react": "0.0.1",
+    "@gillianplatform/sedap-react": "0.0.2",
     "react": "^19.0.0",
     "react-icons": "^5.4.0"
   },


### PR DESCRIPTION
- Enforce the order of submaps when multiple are present
  This is achieved by wrapping each submap in a "fake" node that is assigned priority to enforce order; these fake nodes are then stripped after layout and before rendering.
- Tweak target handle on empty nodes
