### PR TITLE
Fix "fit view" button

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gillianplatform/sedap",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Monorepo for JavaScript libraries for SEDAP",
   "repository":"https://github.com/gillianplatform/sedap-js",
   "workspaces": [

--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gillianplatform/sedap-react",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "React components for SEDAP",
   "repository":"https://github.com/gillianplatform/sedap-js",
   "type": "module",
@@ -27,7 +27,7 @@
     "@eslint/compat": "^1.2.4",
     "@eslint/eslintrc": "^3.2.0",
     "@eslint/js": "^9.17.0",
-    "@gillianplatform/sedap-types": "0.0.5",
+    "@gillianplatform/sedap-types": "0.0.6",
     "@storybook/addon-essentials": "^8.4.7",
     "@storybook/addon-interactions": "^8.4.7",
     "@storybook/addon-onboarding": "^8.4.7",

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gillianplatform/sedap-types",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "SEDAP types for TypeScript",
   "repository":"https://github.com/gillianplatform/sedap-js",
   "types": "./src/index.d.ts",

--- a/vscode/ext/package.json
+++ b/vscode/ext/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gillianplatform/sedap-vscode-ext",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "SEDAP-related utilities for VSCode extensions",
   "repository":"https://github.com/gillianplatform/sedap-js",
   "type": "commonjs",
@@ -27,8 +27,8 @@
     "@eslint/compat": "^1.2.4",
     "@eslint/eslintrc": "^3.2.0",
     "@eslint/js": "^9.17.0",
-    "@gillianplatform/sedap-types": "0.0.5",
-    "@gillianplatform/sedap-vscode-types": "0.0.5",
+    "@gillianplatform/sedap-types": "0.0.6",
+    "@gillianplatform/sedap-vscode-types": "0.0.6",
     "@types/vscode": "^1.96.0",
     "@typescript-eslint/eslint-plugin": "^8.18.2",
     "@typescript-eslint/parser": "^8.18.2",

--- a/vscode/types/package.json
+++ b/vscode/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gillianplatform/sedap-vscode-types",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Types for SEDAP VSCode helper libraries",
   "repository":"https://github.com/gillianplatform/sedap-js",
   "types": "./src/index.d.ts",
@@ -8,7 +8,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@gillianplatform/sedap-types": "0.0.5",
+    "@gillianplatform/sedap-types": "0.0.6",
     "typescript": "^5.7.2"
   }
 }

--- a/vscode/ui/package.json
+++ b/vscode/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gillianplatform/sedap-vscode-ui",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "SEDAP-related utilities for webviews inside VSCode extensions",
   "repository":"https://github.com/gillianplatform/sedap-js",
   "type": "module",
@@ -25,8 +25,8 @@
     "@eslint/compat": "^1.2.4",
     "@eslint/eslintrc": "^3.2.0",
     "@eslint/js": "^9.17.0",
-    "@gillianplatform/sedap-types": "0.0.5",
-    "@gillianplatform/sedap-vscode-types": "0.0.5",
+    "@gillianplatform/sedap-types": "0.0.6",
+    "@gillianplatform/sedap-vscode-types": "0.0.6",
     "@types/react": "^19.0.2",
     "@types/vscode-webview": "^1.57.5",
     "@typescript-eslint/eslint-plugin": "^8.18.2",
@@ -46,7 +46,7 @@
     "vite-plugin-dts": "^4.4.0"
   },
   "peerDependencies": {
-    "@gillianplatform/sedap-react": "0.0.5",
+    "@gillianplatform/sedap-react": "0.0.6",
     "react": "^19.0.0",
     "react-icons": "^5.4.0"
   },


### PR DESCRIPTION
Turns out if you're manually specifying nodes for ReactFlow, you need to provide an `onNodesChange` function to propagate this to ReactFlow.
(Discovered this [here](https://github.com/xyflow/xyflow/issues/5122))
